### PR TITLE
Update build_docs_pages_static.yml

### DIFF
--- a/.github/workflows/build_docs_pages_static.yml
+++ b/.github/workflows/build_docs_pages_static.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
     - main
+    paths:
+    - "Core/**.cs" # only automatically rebuild when modifications are made to the core
+    - "docfx_project/" # or when the docfx project settings are changed
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Improved the documentation build workflow that builds and pushes documentation to GitHub Pages. It now _should_ only run automatically when there are changes to `Core/` or `docfx_project/`, which are the key players for the documentation.