### PR TITLE
Formatted GUI to be more space efficient

### DIFF
--- a/Core/Assets/Theme/button/check-btn-checked.tres
+++ b/Core/Assets/Theme/button/check-btn-checked.tres
@@ -1,13 +1,13 @@
 [gd_resource type="StyleBoxFlat" format=3 uid="uid://cmp3kl8vpwgc7"]
 
 [resource]
-content_margin_left = 10.0
-content_margin_top = 10.0
-content_margin_right = 10.0
-content_margin_bottom = 10.0
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
 bg_color = Color(0.52549, 0.52549, 0.52549, 1)
 border_color = Color(0.0980392, 0.0980392, 0.0980392, 1)
-corner_radius_top_left = 16
-corner_radius_top_right = 16
-corner_radius_bottom_right = 16
-corner_radius_bottom_left = 16
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/Core/Assets/Theme/button/focus.tres
+++ b/Core/Assets/Theme/button/focus.tres
@@ -1,17 +1,18 @@
 [gd_resource type="StyleBoxFlat" format=3 uid="uid://c48bw1mi4cidl"]
 
 [resource]
-content_margin_left = 10.0
-content_margin_top = 10.0
-content_margin_right = 10.0
-content_margin_bottom = 10.0
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
 bg_color = Color(0.160784, 0.160784, 0.160784, 1)
-border_width_left = 5
-border_width_top = 5
-border_width_right = 5
-border_width_bottom = 5
+border_width_left = 2
+border_width_top = 1
+border_width_right = 2
+border_width_bottom = 1
 border_color = Color(1, 1, 1, 1)
-corner_radius_top_left = 16
-corner_radius_top_right = 16
-corner_radius_bottom_right = 16
-corner_radius_bottom_left = 16
+border_blend = true
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/Core/Assets/Theme/button/normal.tres
+++ b/Core/Assets/Theme/button/normal.tres
@@ -1,13 +1,12 @@
 [gd_resource type="StyleBoxFlat" format=3 uid="uid://jntifr8fgmo5"]
 
 [resource]
-content_margin_left = 10.0
-content_margin_top = 10.0
-content_margin_right = 5.0
-content_margin_bottom = 10.0
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
 bg_color = Color(0.160784, 0.160784, 0.160784, 1)
-border_blend = true
-corner_radius_top_left = 16
-corner_radius_top_right = 16
-corner_radius_bottom_right = 16
-corner_radius_bottom_left = 16
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/Core/Assets/Theme/button/pressed.tres
+++ b/Core/Assets/Theme/button/pressed.tres
@@ -1,17 +1,18 @@
 [gd_resource type="StyleBoxFlat" format=3 uid="uid://be68kynsimpmn"]
 
 [resource]
-content_margin_left = 10.0
-content_margin_top = 10.0
-content_margin_right = 10.0
-content_margin_bottom = 10.0
-bg_color = Color(0.898039, 0.898039, 0.898039, 0.384314)
-border_width_left = 5
-border_width_top = 5
-border_width_right = 5
-border_width_bottom = 5
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+bg_color = Color(0.9, 0.9, 0.9, 0.831373)
+border_width_left = 2
+border_width_top = 1
+border_width_right = 2
+border_width_bottom = 1
 border_color = Color(0.0980392, 0.0980392, 0.0980392, 1)
-corner_radius_top_left = 16
-corner_radius_top_right = 16
-corner_radius_bottom_right = 16
-corner_radius_bottom_left = 16
+border_blend = true
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/Core/Assets/Theme/default_theme.tres
+++ b/Core/Assets/Theme/default_theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=24 format=3 uid="uid://b6m4xd68fa5um"]
+[gd_resource type="Theme" load_steps=23 format=3 uid="uid://b6m4xd68fa5um"]
 
 [ext_resource type="FontFile" uid="uid://cpkb4mv46vfpb" path="res://Core/Assets/Fonts/DelaGothicOne-Regular.ttf" id="1_l51w2"]
 [ext_resource type="StyleBox" uid="uid://jntifr8fgmo5" path="res://Core/Assets/Theme/button/normal.tres" id="1_rmmgv"]
@@ -39,11 +39,9 @@ load_path = "res://.godot/imported/grey_tickGrey.png-a26f08745dad8b33759a696908a
 [sub_resource type="CompressedTexture2D" id="CompressedTexture2D_jvfsg"]
 load_path = "res://.godot/imported/grey_tickWhite.png-643ddf3df4188774169e257320c1b1f4.ctex"
 
-[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_25o63"]
-
 [resource]
 default_font = ExtResource("1_l51w2")
-default_font_size = 22
+default_font_size = 16
 Button/colors/icon_focus_color = Color(0.427451, 0.427451, 0.427451, 1)
 Button/colors/icon_hover_color = Color(0.427451, 0.427451, 0.427451, 1)
 Button/colors/icon_hover_pressed_color = Color(0.427451, 0.427451, 0.427451, 0.352941)
@@ -53,7 +51,7 @@ Button/styles/focus = ExtResource("2_j5yxf")
 Button/styles/hover = ExtResource("2_j5yxf")
 Button/styles/normal = ExtResource("1_rmmgv")
 Button/styles/pressed = ExtResource("3_paclo")
-CheckBox/constants/h_separation = 16
+CheckBox/constants/h_separation = 8
 CheckBox/icons/checked = SubResource("CompressedTexture2D_0vptf")
 CheckBox/icons/radio_checked = SubResource("CompressedTexture2D_568m8")
 CheckBox/icons/radio_unchecked = SubResource("CompressedTexture2D_5s7yx")
@@ -71,7 +69,11 @@ HSlider/icons/grabber_highlight = SubResource("CompressedTexture2D_jvfsg")
 HSlider/styles/grabber_area = ExtResource("14_w7t2j")
 HSlider/styles/grabber_area_highlight = ExtResource("14_2hr5b")
 LinkButton/styles/focus = ExtResource("2_j5yxf")
-OptionButton/icons/arrow = SubResource("CompressedTexture2D_25o63")
+MarginContainer/constants/margin_bottom = 8
+MarginContainer/constants/margin_left = 8
+MarginContainer/constants/margin_right = 8
+MarginContainer/constants/margin_top = 8
+OptionButton/icons/arrow = null
 PanelContainer/styles/panel = ExtResource("2_o84u2")
 PopupMenu/icons/checked = SubResource("CompressedTexture2D_0vptf")
 PopupMenu/icons/radio_checked = SubResource("CompressedTexture2D_568m8")

--- a/Core/Assets/Theme/panel-container/panel-container.tres
+++ b/Core/Assets/Theme/panel-container/panel-container.tres
@@ -2,16 +2,12 @@
 
 [resource]
 bg_color = Color(0.223529, 0.121569, 0.376471, 1)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
 border_color = Color(0.501961, 0.501961, 0.501961, 1)
-corner_radius_top_left = 16
-corner_radius_top_right = 16
-corner_radius_bottom_right = 16
-corner_radius_bottom_left = 16
-expand_margin_left = 5.0
-expand_margin_top = 5.0
-expand_margin_right = 5.0
-expand_margin_bottom = 5.0
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8

--- a/Core/Assets/Theme/scroll/grabber-highlight.tres
+++ b/Core/Assets/Theme/scroll/grabber-highlight.tres
@@ -1,11 +1,9 @@
 [gd_resource type="StyleBoxFlat" format=3 uid="uid://cng3h52ckhnfu"]
 
 [resource]
-content_margin_left = 5.0
-content_margin_bottom = 5.0
 bg_color = Color(0.905882, 0.905882, 0.905882, 1)
-corner_radius_top_left = 10
-corner_radius_top_right = 10
-corner_radius_bottom_right = 10
-corner_radius_bottom_left = 10
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
 expand_margin_left = 10.0

--- a/Core/Assets/Theme/scroll/grabber-normal.tres
+++ b/Core/Assets/Theme/scroll/grabber-normal.tres
@@ -1,10 +1,8 @@
 [gd_resource type="StyleBoxFlat" format=3 uid="uid://ow0cd4moqfiv"]
 
 [resource]
-content_margin_left = 5.0
-content_margin_bottom = 5.0
 bg_color = Color(0.447059, 0.447059, 0.447059, 1)
-corner_radius_top_left = 10
-corner_radius_top_right = 10
-corner_radius_bottom_right = 10
-corner_radius_bottom_left = 10
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/Core/Assets/Theme/sep-line/horizontal.tres
+++ b/Core/Assets/Theme/sep-line/horizontal.tres
@@ -2,6 +2,4 @@
 
 [resource]
 color = Color(0.368627, 0.368627, 0.368627, 1)
-grow_begin = 10.0
-grow_end = 10.0
 thickness = 4

--- a/Core/Assets/Theme/sep-line/vertical.tres
+++ b/Core/Assets/Theme/sep-line/vertical.tres
@@ -2,7 +2,5 @@
 
 [resource]
 color = Color(0.368627, 0.368627, 0.368627, 1)
-grow_begin = 10.0
-grow_end = 10.0
 thickness = 4
 vertical = true

--- a/Core/Assets/Theme/slider/active-highlight.tres
+++ b/Core/Assets/Theme/slider/active-highlight.tres
@@ -2,5 +2,7 @@
 
 [resource]
 bg_color = Color(0.886275, 0.886275, 0.886275, 1)
-expand_margin_top = 3.0
-expand_margin_bottom = 3.0
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/Core/Assets/Theme/slider/active.tres
+++ b/Core/Assets/Theme/slider/active.tres
@@ -2,3 +2,7 @@
 
 [resource]
 bg_color = Color(0.8, 0.8, 0.8, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/Core/Assets/Theme/tab-container/tab-active.tres
+++ b/Core/Assets/Theme/tab-container/tab-active.tres
@@ -3,8 +3,11 @@
 [resource]
 content_margin_left = 16.0
 content_margin_right = 16.0
-bg_color = Color(0, 0, 0, 1)
+bg_color = Color(0.4, 0.4, 0.4, 1)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
 border_width_bottom = 2
-corner_radius_top_left = 16
-corner_radius_top_right = 16
-expand_margin_top = 16.0
+border_blend = true
+corner_radius_top_left = 4
+corner_radius_top_right = 4

--- a/Core/Assets/Theme/tab-container/tab-inactive.tres
+++ b/Core/Assets/Theme/tab-container/tab-inactive.tres
@@ -3,6 +3,6 @@
 [resource]
 content_margin_left = 16.0
 content_margin_right = 16.0
-bg_color = Color(0.0980392, 0.0980392, 0.0980392, 1)
-corner_radius_top_left = 16
-corner_radius_top_right = 16
+bg_color = Color(0.4, 0.4, 0.4, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4

--- a/Core/Scenes/UI/Menus/OptionsTabs/accessibility_tab.tscn
+++ b/Core/Scenes/UI/Menus/OptionsTabs/accessibility_tab.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://5lm2kfqmwx7b"]
+[gd_scene load_steps=8 format=3 uid="uid://5lm2kfqmwx7b"]
 
 [ext_resource type="Script" path="res://Core/Scenes/UI/Menus/OptionsTabs/AccessibilityTab.cs" id="1_qvlnx"]
 [ext_resource type="Script" path="res://Core/Scenes/UI/Menus/OptionsTabs/CheckToggleDescriptions.gd" id="2_kk8x0"]
@@ -7,29 +7,32 @@
 [ext_resource type="Script" path="res://Core/Scenes/UI/Menus/OptionsTabs/clear_scroll.gd" id="3_m8o3s"]
 [ext_resource type="Script" path="res://Core/Modules/GUI/SlidingPanelComponent.cs" id="6_8fdip"]
 
+[sub_resource type="LabelSettings" id="LabelSettings_r345i"]
+font_size = 22
+outline_size = 8
+outline_color = Color(0, 0, 0, 1)
+
 [node name="Accessibility" type="PanelContainer" node_paths=PackedStringArray("_checkboxNoFlashingLights", "_sliderRumbleStrength", "_sliderScreenShakeStrength", "_sliderRumbleDuration", "_sliderScreenShakeDuration", "_sliderMaxVolume", "_sliderTimeScale", "_sliderGUIScale", "_optionFont", "_checkAlwaysShowReticle")]
 anchors_preset = 9
 anchor_bottom = 1.0
-offset_right = 1051.0
+offset_right = 761.0
 grow_vertical = 2
+size_flags_horizontal = 2
+size_flags_vertical = 3
 script = ExtResource("1_qvlnx")
-_checkboxNoFlashingLights = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/FlashingLights/CheckBox_NoFlashingLights")
-_sliderRumbleStrength = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble/Stength/HBoxContainer/HSlider")
-_sliderScreenShakeStrength = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake/Stength/HBoxContainer/HSlider")
-_sliderRumbleDuration = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble/MaxDuration/HBoxContainer/HSlider")
-_sliderScreenShakeDuration = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake/MaxDuration/HBoxContainer/HSlider")
-_sliderMaxVolume = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AudioLimit/SliderCombo/HBoxContainer/HSlider")
-_sliderTimeScale = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/EngineTimeScale/Stength/HBoxContainer/HSlider")
-_sliderGUIScale = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/UIScaling/SliderCombo/HBoxContainer/HSlider")
-_optionFont = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/FontStyle2/FontStyle")
-_checkAlwaysShowReticle = NodePath("MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AlwaysShowReticle/CheckBox")
+_checkboxNoFlashingLights = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/FlashingLights/CheckBox_NoFlashingLights")
+_sliderRumbleStrength = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble/Stength/HBoxContainer/HSlider")
+_sliderScreenShakeStrength = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake/Stength/HBoxContainer/HSlider")
+_sliderRumbleDuration = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble/MaxDuration/HBoxContainer/HSlider")
+_sliderScreenShakeDuration = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake/MaxDuration/HBoxContainer/HSlider")
+_sliderMaxVolume = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AudioLimit/SliderCombo/HBoxContainer/HSlider")
+_sliderTimeScale = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/EngineTimeScale/Stength/HBoxContainer/HSlider")
+_sliderGUIScale = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/UIScaling/SliderCombo/HBoxContainer/HSlider")
+_optionFont = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/FontStyleComponent/FontStyle")
+_checkAlwaysShowReticle = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AlwaysShowReticle/CheckBox")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-theme_override_constants/margin_left = 32
-theme_override_constants/margin_top = 32
-theme_override_constants/margin_right = 32
-theme_override_constants/margin_bottom = 32
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
@@ -37,15 +40,12 @@ layout_mode = 2
 [node name="Label" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "Accessibility Options"
+label_settings = SubResource("LabelSettings_r345i")
 horizontal_alignment = 1
-
-[node name="HSeparator2" type="HSeparator" parent="MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 16)
-layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
-alignment = 1
+alignment = 2
 
 [node name="BtnApplyChanges" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
@@ -61,37 +61,38 @@ script = ExtResource("2_kk8x0")
 
 [node name="UIEffects" parent="MarginContainer/VBoxContainer/HBoxContainer/CheckToggleDescriptions" instance=ExtResource("2_n5o3d")]
 
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
 [node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 0.08)
 layout_mode = 2
 size_flags_vertical = 3
 follow_focus = true
-scroll_vertical = 100
+scroll_vertical = 602
 horizontal_scroll_mode = 0
 script = ExtResource("3_m8o3s")
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+self_modulate = Color(0.74902, 0.74902, 0.74902, 1)
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_constants/margin_left = 32
-theme_override_constants/margin_top = 32
-theme_override_constants/margin_right = 32
-theme_override_constants/margin_bottom = 64
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer"]
 layout_mode = 2
-size_flags_horizontal = 3
+
+[node name="Content" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer"]
+layout_mode = 2
 size_flags_vertical = 0
 
-[node name="FontStyle2" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="FontStyleComponent" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Label5" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/FontStyle2"]
+[node name="Label5" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/FontStyleComponent"]
 layout_mode = 2
 text = "UI Font"
 horizontal_alignment = 1
 
-[node name="FontStyle" type="OptionButton" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/FontStyle2"]
+[node name="FontStyle" type="OptionButton" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/FontStyleComponent"]
 layout_mode = 2
 item_count = 3
 selected = 0
@@ -102,223 +103,191 @@ popup/item_1/id = 1
 popup/item_2/text = "OpenDyslexie (may help with dyslexia)"
 popup/item_2/id = 2
 
-[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/FontStyle2/FontStyle" instance=ExtResource("2_n5o3d")]
+[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/FontStyleComponent/FontStyle" instance=ExtResource("2_n5o3d")]
 
-[node name="Spacing" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 32)
-layout_mode = 2
-theme_override_constants/separation = 64
-
-[node name="FlashingLights" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Spacing" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Label4" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/FlashingLights"]
+[node name="FlashingLights" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
+layout_mode = 2
+
+[node name="Label4" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/FlashingLights"]
 layout_mode = 2
 text = "Flashing Lights"
 horizontal_alignment = 1
 
-[node name="CheckBox_NoFlashingLights" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/FlashingLights"]
+[node name="CheckBox_NoFlashingLights" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/FlashingLights"]
 layout_mode = 2
 text = "Less Flashing Lights"
 
-[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/FlashingLights/CheckBox_NoFlashingLights" instance=ExtResource("2_n5o3d")]
+[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/FlashingLights/CheckBox_NoFlashingLights" instance=ExtResource("2_n5o3d")]
 
-[node name="HSeparator2" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Spacing2" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Spacing2" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 32)
-layout_mode = 2
-theme_override_constants/separation = 64
-
-[node name="UIScaling" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="UIScaling" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Label3" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/UIScaling"]
+[node name="SliderCombo" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/UIScaling" instance=ExtResource("2_wr3cm")]
 layout_mode = 2
 text = "GUI Scaling (Currently has no effect)"
-horizontal_alignment = 1
 
-[node name="SliderCombo" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/UIScaling" instance=ExtResource("2_wr3cm")]
-layout_mode = 2
-text = "Scale"
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/UIScaling/SliderCombo" index="0"]
+text = "GUI Scaling (Currently has no effect)"
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/UIScaling/SliderCombo" index="0"]
-text = "Scale"
-
-[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/UIScaling" groups=["access_description"]]
+[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/UIScaling" groups=["access_description"]]
 layout_mode = 2
 text = "Applies a global scaling to user interfaces. This can make it easier to read UI on various screen sizes. The structure is made for the screen I have which is 1920x1080. This effect is global and may have some unintended repurcussions. Start small at first to avoid complications. "
 autowrap_mode = 3
 
-[node name="AudioLimit" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Spacing7" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Label3" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AudioLimit"]
+[node name="AudioLimit" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
-text = "Volume Limiting"
-horizontal_alignment = 1
 
-[node name="SliderCombo" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AudioLimit" instance=ExtResource("2_wr3cm")]
+[node name="SliderCombo" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AudioLimit" instance=ExtResource("2_wr3cm")]
 layout_mode = 2
-text = "In decibels"
+text = "Volume Limiting (dB)"
 slider_value = -6.0
 min_value = -72.0
 max_value = -6.0
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AudioLimit/SliderCombo" index="0"]
-text = "In decibels"
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AudioLimit/SliderCombo" index="0"]
+text = "Volume Limiting (dB)"
 
-[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AudioLimit/SliderCombo/HBoxContainer" index="0"]
+[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AudioLimit/SliderCombo/HBoxContainer" index="0"]
 min_value = -72.0
 max_value = -6.0
 value = -6.0
 
-[node name="ValueLbl" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AudioLimit/SliderCombo/HBoxContainer" index="1"]
+[node name="ValueLbl" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AudioLimit/SliderCombo/HBoxContainer" index="1"]
 text = "-6"
 
-[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AudioLimit" groups=["access_description"]]
+[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AudioLimit" groups=["access_description"]]
 layout_mode = 2
 text = "Applies a limiter to the audio system. Can produce some auditory artifacts, but the goal is to ensure the volume never caps out too high. Measurement is in decibels. "
 autowrap_mode = 3
 
-[node name="HSeparator5" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Spacing5" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Spacing5" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 32)
-layout_mode = 2
-theme_override_constants/separation = 64
-
-[node name="ScreenShake" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="ScreenShake" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake"]
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake"]
 layout_mode = 2
 text = "Screen Shake"
 horizontal_alignment = 1
 
-[node name="Stength" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake" instance=ExtResource("2_wr3cm")]
+[node name="Stength" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake" instance=ExtResource("2_wr3cm")]
 layout_mode = 2
 text = "Strength"
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake/Stength" index="0"]
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake/Stength" index="0"]
 text = "Strength"
 
-[node name="MaxDuration" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake" instance=ExtResource("2_wr3cm")]
+[node name="MaxDuration" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake" instance=ExtResource("2_wr3cm")]
 layout_mode = 2
 text = "Max Duration"
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake/MaxDuration" index="0"]
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake/MaxDuration" index="0"]
 text = "Max Duration"
 
-[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake" groups=["access_description"]]
+[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake" groups=["access_description"]]
 layout_mode = 2
 text = "Screen shake moves the camera to create dramatic effects or even induce unintentional flashing lights. You can limit"
 autowrap_mode = 3
 
-[node name="HSeparator4" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Spacing4" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Spacing4" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 32)
-layout_mode = 2
-theme_override_constants/separation = 64
-
-[node name="ControllerRumble" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="ControllerRumble" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble"]
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble"]
 layout_mode = 2
 text = "Controller Rumble"
 horizontal_alignment = 1
 
-[node name="Stength" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble" instance=ExtResource("2_wr3cm")]
+[node name="Stength" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble" instance=ExtResource("2_wr3cm")]
 layout_mode = 2
 text = "Strength"
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble/Stength" index="0"]
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble/Stength" index="0"]
 text = "Strength"
 
-[node name="MaxDuration" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble" instance=ExtResource("2_wr3cm")]
+[node name="MaxDuration" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble" instance=ExtResource("2_wr3cm")]
 layout_mode = 2
 text = "Max Duration"
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble/MaxDuration" index="0"]
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble/MaxDuration" index="0"]
 text = "Max Duration"
 
-[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble" groups=["access_description"]]
+[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble" groups=["access_description"]]
 layout_mode = 2
 text = "Controller rumble only matters if you are using a game pad and it has enabled rumble motors. Rumble can create a strong dramatic effect. But can also cause sensory overload or even simply numbing if it is too strong for you. Feel free to alter the strength to your liking."
 autowrap_mode = 3
 
-[node name="HSeparator3" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Spacing3" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Spacing3" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 32)
-layout_mode = 2
-theme_override_constants/separation = 64
-
-[node name="AlwaysShowReticle" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="AlwaysShowReticle" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AlwaysShowReticle"]
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AlwaysShowReticle"]
 layout_mode = 2
 text = "Always Show Reticle (Crosshairs)"
 horizontal_alignment = 1
 
-[node name="CheckBox" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AlwaysShowReticle"]
+[node name="CheckBox" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AlwaysShowReticle"]
 layout_mode = 2
 text = "Always Show Reticle"
 
-[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AlwaysShowReticle/CheckBox" instance=ExtResource("2_n5o3d")]
+[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AlwaysShowReticle/CheckBox" instance=ExtResource("2_n5o3d")]
 
-[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AlwaysShowReticle" groups=["access_description"]]
+[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AlwaysShowReticle" groups=["access_description"]]
 layout_mode = 2
 text = "Enabling this check box will make it so the reticle is always visible. This can help with reducing motion sickness for some individuals. "
 autowrap_mode = 3
 
-[node name="EngineTimeScale" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Spacing8" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/EngineTimeScale"]
+[node name="EngineTimeScale" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
-text = "Time Scaling"
-horizontal_alignment = 1
 
-[node name="Stength" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/EngineTimeScale" instance=ExtResource("2_wr3cm")]
+[node name="Stength" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/EngineTimeScale" instance=ExtResource("2_wr3cm")]
 layout_mode = 2
-text = "Time Scale"
+text = "Engine Time Scale (lower is slower)"
+max_value = 2.0
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/EngineTimeScale/Stength" index="0"]
-text = "Time Scale"
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/EngineTimeScale/Stength" index="0"]
+text = "Engine Time Scale (lower is slower)"
 
-[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/EngineTimeScale" groups=["access_description"]]
+[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/EngineTimeScale/Stength/HBoxContainer" index="0"]
+max_value = 2.0
+
+[node name="Label2" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/EngineTimeScale" groups=["access_description"]]
 layout_mode = 2
 text = "Time Scale will change the clock speed of the game. This can help with giving more reaction time, however this will scale all time based operations, so be careful if you choose to alter this. Additonally, there is the option to increase the time scale about 1.0, which will make the game run faster than normal, which could provide an interesting challenge to anyone who really wants it.
 This feature may break some elements. I'll do my best to make sure it doesn't. Please report any bugs you encounter while using this feature."
 autowrap_mode = 3
 
-[node name="HSeparator6" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Spacing6" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 
-[node name="Spacing6" type="HSeparator" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 32)
-layout_mode = 2
-theme_override_constants/separation = 64
-
-[node name="Label3" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Label3" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 text = "If you have a request for an accessibility option to be implemented, let me know! I can do my best to add it in!"
 autowrap_mode = 3
 
-[node name="LinkButton" type="LinkButton" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="LinkButton" type="LinkButton" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content"]
 layout_mode = 2
 text = "Submit a request on the GitHub Respository (Requires a free GitHub account)"
-uri = "https://github.com/QueenOfSquiggles/Squiggle-Zone-Game-Base/issues/new"
+uri = "https://github.com/QueenOfSquiggles/Squiggles-Core-4X/issues"
 
-[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/LinkButton" instance=ExtResource("2_n5o3d")]
+[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/LinkButton" instance=ExtResource("2_n5o3d")]
 
 [node name="SlidingPanelComponent" type="Node" parent="." node_paths=PackedStringArray("_target")]
 script = ExtResource("6_8fdip")
@@ -326,12 +295,12 @@ _target = NodePath("..")
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/BtnApplyChanges" to="." method="ApplyChanges"]
 [connection signal="toggled" from="MarginContainer/VBoxContainer/HBoxContainer/CheckToggleDescriptions" to="MarginContainer/VBoxContainer/HBoxContainer/CheckToggleDescriptions" method="_on_toggled"]
-[connection signal="toggled" from="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/FlashingLights/CheckBox_NoFlashingLights" to="." method="OnNoFlashingLightsChanged"]
+[connection signal="toggled" from="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/FlashingLights/CheckBox_NoFlashingLights" to="." method="OnNoFlashingLightsChanged"]
 
-[editable path="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/UIScaling/SliderCombo"]
-[editable path="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/AudioLimit/SliderCombo"]
-[editable path="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake/Stength"]
-[editable path="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ScreenShake/MaxDuration"]
-[editable path="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble/Stength"]
-[editable path="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ControllerRumble/MaxDuration"]
-[editable path="MarginContainer/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/EngineTimeScale/Stength"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/UIScaling/SliderCombo"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/AudioLimit/SliderCombo"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake/Stength"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ScreenShake/MaxDuration"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble/Stength"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/ControllerRumble/MaxDuration"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/MarginContainer/Content/EngineTimeScale/Stength"]

--- a/Core/Scenes/UI/Menus/OptionsTabs/audio_tab.tscn
+++ b/Core/Scenes/UI/Menus/OptionsTabs/audio_tab.tscn
@@ -11,19 +11,16 @@ font_size = 32
 [node name="AudioOptions" type="PanelContainer" node_paths=PackedStringArray("_slidersRoot")]
 anchors_preset = 9
 anchor_bottom = 1.0
-offset_right = 346.0
+offset_right = 508.0
 grow_vertical = 2
+size_flags_horizontal = 0
 size_flags_vertical = 4
 script = ExtResource("1_uko75")
-_slidersRoot = NodePath("MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer")
+_slidersRoot = NodePath("MarginContainer/VBoxContainer/ScrollContainer/PanelContainer/VBoxContainer")
 _sliderComboScene = ExtResource("2_wor7r")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-theme_override_constants/margin_left = 32
-theme_override_constants/margin_top = 32
-theme_override_constants/margin_right = 32
-theme_override_constants/margin_bottom = 32
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
@@ -47,10 +44,15 @@ text = "Apply Changes"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 0
 size_flags_vertical = 3
 horizontal_scroll_mode = 0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+self_modulate = Color(0.75, 0.75, 0.75, 1)
+layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/PanelContainer"]
 custom_minimum_size = Vector2(480, 0)
 layout_mode = 2
 size_flags_horizontal = 3

--- a/Core/Scenes/UI/Menus/OptionsTabs/controls_tab.tscn
+++ b/Core/Scenes/UI/Menus/OptionsTabs/controls_tab.tscn
@@ -7,29 +7,25 @@
 [ext_resource type="Script" path="res://Core/Modules/GUI/SlidingPanelComponent.cs" id="5_dayim"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_4loes"]
-font_size = 32
+font_size = 22
 
 [node name="ControlSettings" type="PanelContainer" node_paths=PackedStringArray("_popupListening", "_sliderMouse", "_sliderGamepad", "_mappingRoot")]
-custom_minimum_size = Vector2(720, 0)
 anchors_preset = 9
 anchor_bottom = 1.0
-offset_right = 76.0
+offset_right = 388.0
 grow_vertical = 2
-size_flags_horizontal = 3
+size_flags_horizontal = 0
 size_flags_vertical = 3
 script = ExtResource("1_y6pcj")
-_popupListening = NodePath("SlidingRoot/ListeningPopup")
-_sliderMouse = NodePath("MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/MouseSensitivity/HBoxContainer/HSlider")
-_sliderGamepad = NodePath("MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/GamepadSensitivity/HBoxContainer/HSlider")
-_mappingRoot = NodePath("MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings")
+_popupListening = NodePath("ListeningPopup")
+_sliderMouse = NodePath("MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/MouseSensitivity/HBoxContainer/HSlider")
+_sliderGamepad = NodePath("MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/GamepadSensitivity/HBoxContainer/HSlider")
+_mappingRoot = NodePath("MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings")
 _mappingScene = ExtResource("3_hxwhr")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-theme_override_constants/margin_left = 32
-theme_override_constants/margin_top = 32
-theme_override_constants/margin_right = 32
-theme_override_constants/margin_bottom = 32
+size_flags_horizontal = 0
 
 [node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer"]
 layout_mode = 2
@@ -37,7 +33,6 @@ horizontal_scroll_mode = 0
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer/ScrollContainer"]
 layout_mode = 2
-theme_override_constants/margin_right = 32
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/MarginContainer"]
 layout_mode = 2
@@ -54,19 +49,26 @@ horizontal_alignment = 1
 [node name="HSeparator" type="HSeparator" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Sensitivity" type="VBoxContainer" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+self_modulate = Color(0.75, 0.75, 0.75, 1)
 layout_mode = 2
 
-[node name="LblSensitivity" type="Label" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer"]
+layout_mode = 2
+
+[node name="Sensitivity" type="VBoxContainer" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="LblSensitivity" type="Label" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity"]
 layout_mode = 2
 text = "Sensitivities
 "
 horizontal_alignment = 1
 
-[node name="HSeparator" type="HSeparator" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity"]
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity"]
 layout_mode = 2
 
-[node name="MouseSensitivity" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity" instance=ExtResource("2_midyy")]
+[node name="MouseSensitivity" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity" instance=ExtResource("2_midyy")]
 layout_mode = 2
 text = "Mouse"
 slider_value = 400.0
@@ -74,19 +76,19 @@ min_value = 1.0
 max_value = 1000.0
 step_value = 5.0
 
-[node name="Lbl" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/MouseSensitivity" index="0"]
+[node name="Lbl" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/MouseSensitivity" index="0"]
 text = "Mouse"
 
-[node name="HSlider" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/MouseSensitivity/HBoxContainer" index="0"]
+[node name="HSlider" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/MouseSensitivity/HBoxContainer" index="0"]
 min_value = 1.0
 max_value = 1000.0
 step = 5.0
 value = 401.0
 
-[node name="ValueLbl" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/MouseSensitivity/HBoxContainer" index="1"]
+[node name="ValueLbl" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/MouseSensitivity/HBoxContainer" index="1"]
 text = "401"
 
-[node name="GamepadSensitivity" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity" instance=ExtResource("2_midyy")]
+[node name="GamepadSensitivity" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity" instance=ExtResource("2_midyy")]
 layout_mode = 2
 text = "Gamepad"
 slider_value = 500.0
@@ -94,53 +96,52 @@ min_value = 1.0
 max_value = 1000.0
 step_value = 5.0
 
-[node name="Lbl" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/GamepadSensitivity" index="0"]
+[node name="Lbl" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/GamepadSensitivity" index="0"]
 text = "Gamepad"
 
-[node name="HSlider" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/GamepadSensitivity/HBoxContainer" index="0"]
+[node name="HSlider" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/GamepadSensitivity/HBoxContainer" index="0"]
 min_value = 1.0
 max_value = 1000.0
 step = 5.0
 value = 501.0
 
-[node name="ValueLbl" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/GamepadSensitivity/HBoxContainer" index="1"]
+[node name="ValueLbl" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/GamepadSensitivity/HBoxContainer" index="1"]
 text = "501"
 
-[node name="Mappings" type="VBoxContainer" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Mappings" type="VBoxContainer" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/separation = 16
 
-[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings"]
+[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings"]
 layout_mode = 2
 text = "Controls Mappings"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings"]
 layout_mode = 2
 alignment = 1
 
-[node name="BtnApplyChanges" type="Button" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings/HBoxContainer"]
+[node name="BtnApplyChanges" type="Button" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Apply Changes"
 
-[node name="UISounds" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings/HBoxContainer/BtnApplyChanges" instance=ExtResource("3_k08te")]
+[node name="UISounds" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings/HBoxContainer/BtnApplyChanges" instance=ExtResource("3_k08te")]
 
-[node name="BtnResetAll" type="Button" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings/HBoxContainer"]
+[node name="BtnResetAll" type="Button" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Reset All Mappings"
 
-[node name="UISounds" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings/HBoxContainer/BtnResetAll" instance=ExtResource("3_k08te")]
+[node name="UISounds" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings/HBoxContainer/BtnResetAll" instance=ExtResource("3_k08te")]
 
-[node name="HSeparator" type="HSeparator" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings"]
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings"]
 layout_mode = 2
 
-[node name="SlidingRoot" type="Control" parent="."]
-layout_mode = 2
-mouse_filter = 2
-
-[node name="ListeningPopup" type="Popup" parent="SlidingRoot"]
+[node name="ListeningPopup" type="Popup" parent="."]
 disable_3d = true
 title = "Listening For Input"
 initial_position = 2
@@ -148,14 +149,14 @@ size = Vector2i(480, 360)
 always_on_top = true
 transparent = true
 
-[node name="CenterContainer" type="CenterContainer" parent="SlidingRoot/ListeningPopup"]
+[node name="CenterContainer" type="CenterContainer" parent="ListeningPopup"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="Label" type="Label" parent="SlidingRoot/ListeningPopup/CenterContainer"]
+[node name="Label" type="Label" parent="ListeningPopup/CenterContainer"]
 layout_mode = 2
 text = "Listening For Input
 Press any button to assign!"
@@ -166,8 +167,8 @@ vertical_alignment = 1
 script = ExtResource("5_dayim")
 _target = NodePath("..")
 
-[connection signal="pressed" from="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings/HBoxContainer/BtnApplyChanges" to="." method="ApplyChanges"]
-[connection signal="pressed" from="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Mappings/HBoxContainer/BtnResetAll" to="." method="ResetAllMappings"]
+[connection signal="pressed" from="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings/HBoxContainer/BtnApplyChanges" to="." method="ApplyChanges"]
+[connection signal="pressed" from="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Mappings/HBoxContainer/BtnResetAll" to="." method="ResetAllMappings"]
 
-[editable path="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/MouseSensitivity"]
-[editable path="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/Sensitivity/GamepadSensitivity"]
+[editable path="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/MouseSensitivity"]
+[editable path="MarginContainer/ScrollContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/Sensitivity/GamepadSensitivity"]

--- a/Core/Scenes/UI/Menus/OptionsTabs/gameplay_tab.tscn
+++ b/Core/Scenes/UI/Menus/OptionsTabs/gameplay_tab.tscn
@@ -9,8 +9,9 @@ font_size = 32
 [node name="GameplayTab" type="PanelContainer" node_paths=PackedStringArray("_content")]
 anchors_preset = 9
 anchor_bottom = 1.0
-offset_right = 4.0
+offset_right = 435.0
 grow_vertical = 2
+size_flags_horizontal = 0
 script = ExtResource("1_03j23")
 _content = NodePath("MarginContainer/ScrollContainer/MarginContainer/Content")
 

--- a/Core/Scenes/UI/Menus/OptionsTabs/graphics_tab.tscn
+++ b/Core/Scenes/UI/Menus/OptionsTabs/graphics_tab.tscn
@@ -15,30 +15,26 @@ anchor_bottom = 1.0
 offset_left = 11.0
 offset_right = 33.0
 grow_vertical = 2
+size_flags_horizontal = 0
 script = ExtResource("1_lbres")
 _packedGraphicsDisplay = ExtResource("2_upr2m")
-_optionFullscreen = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/HBoxContainer/OptionFullscreenMode")
-_checkBloom = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckBloom")
-_checkSSR = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckSSR")
-_checkSSAO = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckSSAO")
-_checkSSIL = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckSSIL")
-_checkSDFGI = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckSDFGI")
-_sliderExposure = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideExposure/HBoxContainer/HSlider")
-_sliderBrightness = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideBrightness/HBoxContainer/HSlider")
-_sliderContrast = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideContrast/HBoxContainer/HSlider")
-_sliderSaturation = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideSaturation/HBoxContainer/HSlider")
-_colourCorrectionControls = [NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideExposure"), NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideBrightness"), NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideContrast"), NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideSaturation")]
+_optionFullscreen = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/HBoxContainer/OptionFullscreenMode")
+_checkBloom = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckBloom")
+_checkSSR = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckSSR")
+_checkSSAO = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckSSAO")
+_checkSSIL = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckSSIL")
+_checkSDFGI = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckSDFGI")
+_sliderExposure = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideExposure/HBoxContainer/HSlider")
+_sliderBrightness = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideBrightness/HBoxContainer/HSlider")
+_sliderContrast = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideContrast/HBoxContainer/HSlider")
+_sliderSaturation = NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideSaturation/HBoxContainer/HSlider")
+_colourCorrectionControls = [NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideExposure"), NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideBrightness"), NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideContrast"), NodePath("MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideSaturation")]
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-theme_override_constants/margin_left = 5
-theme_override_constants/margin_top = 5
-theme_override_constants/margin_right = 5
-theme_override_constants/margin_bottom = 5
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
-theme_override_constants/separation = 32
 
 [node name="Label" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
@@ -54,8 +50,6 @@ size_flags_stretch_ratio = 0.1
 
 [node name="GraphicsDisplayRoot" type="MarginContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_right = 10
 
 [node name="BtnApplySettings" type="Button" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
@@ -65,28 +59,31 @@ text = "Apply Graphics Settings"
 [node name="UIEffects" parent="MarginContainer/VBoxContainer/BtnApplySettings" instance=ExtResource("2_u0rvq")]
 
 [node name="ScrollContainer_2" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(500, 200)
 layout_mode = 2
+size_flags_horizontal = 0
 size_flags_vertical = 3
 follow_focus = true
 horizontal_scroll_mode = 0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer_2"]
-custom_minimum_size = Vector2(720, 0)
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/VBoxContainer/ScrollContainer_2"]
+self_modulate = Color(0.75, 0.75, 0.75, 1)
+layout_mode = 2
+size_flags_horizontal = 0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
-theme_override_constants/separation = 5
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
 text = "Window Mode"
 
-[node name="OptionFullscreenMode" type="OptionButton" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/HBoxContainer"]
+[node name="OptionFullscreenMode" type="OptionButton" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 item_count = 4
@@ -101,84 +98,84 @@ popup/item_2/id = 3
 popup/item_3/text = "Full Exclusive"
 popup/item_3/id = 4
 
-[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/HBoxContainer/OptionFullscreenMode" instance=ExtResource("2_u0rvq")]
+[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/HBoxContainer/OptionFullscreenMode" instance=ExtResource("2_u0rvq")]
 
-[node name="CheckBloom" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer"]
+[node name="CheckBloom" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer"]
 layout_mode = 2
 tooltip_text = "The glowing of illuminated objects. 
 Fairly low impact on performance"
 text = "Bloom"
 
-[node name="UIEffects_5" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckBloom" instance=ExtResource("2_u0rvq")]
+[node name="UIEffects_5" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckBloom" instance=ExtResource("2_u0rvq")]
 
-[node name="CheckSSAO" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer"]
+[node name="CheckSSAO" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer"]
 layout_mode = 2
 tooltip_text = "The glowing of illuminated objects. 
 Fairly low impact on performance"
 text = "Screen-Space Ambient Occlusion"
 
-[node name="UIEffects_4" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckSSAO" instance=ExtResource("2_u0rvq")]
+[node name="UIEffects_4" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckSSAO" instance=ExtResource("2_u0rvq")]
 
-[node name="CheckSSR" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer"]
+[node name="CheckSSR" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer"]
 layout_mode = 2
 text = "Screen-Space Reflections"
 
-[node name="UIEffects_3" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckSSR" instance=ExtResource("2_u0rvq")]
+[node name="UIEffects_3" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckSSR" instance=ExtResource("2_u0rvq")]
 
-[node name="CheckSSIL" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer"]
+[node name="CheckSSIL" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer"]
 layout_mode = 2
 text = "Screen-Space Indirect Lighting"
 
-[node name="UIEffects_2" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckSSIL" instance=ExtResource("2_u0rvq")]
+[node name="UIEffects_2" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckSSIL" instance=ExtResource("2_u0rvq")]
 
-[node name="CheckSDFGI" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer"]
+[node name="CheckSDFGI" type="CheckBox" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer"]
 layout_mode = 2
 text = "SDF Global Illumination"
 
-[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/CheckSDFGI" instance=ExtResource("2_u0rvq")]
+[node name="UIEffects" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/CheckSDFGI" instance=ExtResource("2_u0rvq")]
 
-[node name="SlideExposure" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer" instance=ExtResource("2_h61vd")]
+[node name="SlideExposure" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer" instance=ExtResource("2_h61vd")]
 layout_mode = 2
 text = "Exposure"
 max_value = 8.0
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideExposure" index="0"]
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideExposure" index="0"]
 text = "Exposure"
 
-[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideExposure/HBoxContainer" index="0"]
+[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideExposure/HBoxContainer" index="0"]
 max_value = 8.0
 
-[node name="SlideBrightness" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer" instance=ExtResource("2_h61vd")]
+[node name="SlideBrightness" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer" instance=ExtResource("2_h61vd")]
 layout_mode = 2
 text = "Brightness"
 max_value = 2.0
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideBrightness" index="0"]
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideBrightness" index="0"]
 text = "Brightness"
 
-[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideBrightness/HBoxContainer" index="0"]
+[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideBrightness/HBoxContainer" index="0"]
 max_value = 2.0
 
-[node name="SlideContrast" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer" instance=ExtResource("2_h61vd")]
+[node name="SlideContrast" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer" instance=ExtResource("2_h61vd")]
 layout_mode = 2
 text = "Contrast"
 max_value = 2.0
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideContrast" index="0"]
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideContrast" index="0"]
 text = "Contrast"
 
-[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideContrast/HBoxContainer" index="0"]
+[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideContrast/HBoxContainer" index="0"]
 max_value = 2.0
 
-[node name="SlideSaturation" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer" instance=ExtResource("2_h61vd")]
+[node name="SlideSaturation" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer" instance=ExtResource("2_h61vd")]
 layout_mode = 2
 text = "Saturation"
 max_value = 2.0
 
-[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideSaturation" index="0"]
+[node name="Lbl" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideSaturation" index="0"]
 text = "Saturation"
 
-[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideSaturation/HBoxContainer" index="0"]
+[node name="HSlider" parent="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideSaturation/HBoxContainer" index="0"]
 max_value = 2.0
 
 [node name="SlidingPanelComponent" type="Node" parent="." node_paths=PackedStringArray("_target")]
@@ -187,7 +184,7 @@ _target = NodePath("..")
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/BtnApplySettings" to="." method="ApplyGraphicsSettings"]
 
-[editable path="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideExposure"]
-[editable path="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideBrightness"]
-[editable path="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideContrast"]
-[editable path="MarginContainer/VBoxContainer/ScrollContainer_2/VBoxContainer/SlideSaturation"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideExposure"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideBrightness"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideContrast"]
+[editable path="MarginContainer/VBoxContainer/ScrollContainer_2/PanelContainer/VBoxContainer/SlideSaturation"]

--- a/Core/Scenes/UI/Menus/pause_menu.tscn
+++ b/Core/Scenes/UI/Menus/pause_menu.tscn
@@ -85,14 +85,9 @@ mouse_filter = 1
 
 [node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
 layout_mode = 2
-theme_override_constants/margin_left = 32
-theme_override_constants/margin_top = 16
-theme_override_constants/margin_right = 32
-theme_override_constants/margin_bottom = 32
 
 [node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer"]
 layout_mode = 2
-theme_override_constants/separation = 20
 
 [node name="Label" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
@@ -102,7 +97,6 @@ horizontal_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
-theme_override_constants/separation = 32
 
 [node name="BtnContinue" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
@@ -128,7 +122,6 @@ text = "Options"
 
 [node name="HSeparator_2" type="HSeparator" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
-theme_override_constants/separation = 64
 
 [node name="BtnLoadLastSave" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2

--- a/project.godot
+++ b/project.godot
@@ -26,6 +26,8 @@ BGM="*res://Core/Scenes/Utility/Autoload/bgm.tscn"
 
 [display]
 
+window/size/viewport_width=1920
+window/size/viewport_height=1080
 window/size/initial_position_type=3
 
 [dotnet]


### PR DESCRIPTION
Originally I believe that changing the theme resource would solve the space efficiency problem. But as fate would have it, I was quite dumb when originally creating these scenes and made a ton of theme overrides instead of just adjusting the theme to make something consistent. So I did my best to also purge theme overrides. Additionally, the project.godot file has the window size set to 1920x1080, which the resolution of my desktop. This should make it easier to tell if a GUI element will be space efficient or not

Closes #47 