### PR TITLE
Update docfx.json

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -15,7 +15,7 @@
       "includePrivateMembers": true,
       "disableGitFeatures": false,
       "noRestore": false,
-      "namespaceLayout": "flat",
+      "namespaceLayout": "flattened",
       "memberLayout": "samePage",
       "EnumSortOrder": "declaringOrder",
       "allowCompilationErrors": false


### PR DESCRIPTION
Fixes #54 's push which apparently was WRONG bc `flat` != `flattened` but bffr I feel like mature software should at least be able to handle the difference!