### PR TITLE
Implemented API Key Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ _site/
 /**/obj/
 
 _site/
+# SC4X configuration file for secret API keys
+appconfig.json

--- a/Core/Modules/API/Auth.cs
+++ b/Core/Modules/API/Auth.cs
@@ -1,0 +1,22 @@
+namespace Squiggles.Core.API;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// The main method for acquiring authorization keys for different app services.
+/// </summary>
+public static class Auth {
+
+  /// <param name="name">The key name for the value</param>
+  /// <returns>an instance of SecureKey which stores the value while only allowing it to be accessed once.</returns>
+  public static SecureKey GetKey(string name) {
+    var builder = Host.CreateApplicationBuilder();
+    var env = builder.Environment;
+    builder.Configuration
+      .AddJsonFile("appconfig.json", optional: true, reloadOnChange: true)
+      .AddEnvironmentVariables(name);
+    var key = builder.Configuration.GetValue(typeof(string), name);
+    return key is null ? null : new SecureKey(key as string);
+  }
+}

--- a/Core/Modules/API/SecureKey.cs
+++ b/Core/Modules/API/SecureKey.cs
@@ -1,0 +1,19 @@
+namespace Squiggles.Core.API;
+
+/// <summary>
+/// Stores a string value and only allows access to it once.
+/// </summary>
+public sealed class SecureKey {
+
+  private string _value;
+  internal SecureKey(string value) {
+    _value = value;
+  }
+
+  public string GetSecureKey() {
+    var temp = _value;
+    _value = null;
+    return temp;
+  }
+
+}

--- a/SquigglesCommon4X.csproj
+++ b/SquigglesCommon4X.csproj
@@ -6,5 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Chickensoft.GoDotTest" Version="1.2.1" />
-  </ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />  </ItemGroup>
 </Project>

--- a/addons/squiggles_core_autoloads/plugin.gd
+++ b/addons/squiggles_core_autoloads/plugin.gd
@@ -9,7 +9,21 @@ func _enter_tree() -> void:
 
 	# set up project settings
 	ProjectSettings.set_setting("gui/theme/custom", "res://Core/Assets/Theme/default_theme.tres")
+	_hide_api_keys()
 
 func _exit_tree() -> void:
 	remove_autoload_singleton("Scenes")
 	remove_autoload_singleton("BGM")
+
+
+func _hide_api_keys() -> void:
+	if not FileAccess.file_exists("res://appconfig.json"):
+		return # no app.json file to hide
+	var ignoreFile := FileAccess.open("res://.gitignore", FileAccess.READ_WRITE)
+	var contents = ignoreFile.get_as_text()
+	if "appconfig.json" in contents:
+		return
+	ignoreFile.seek_end()
+	ignoreFile.store_line("# SC4X configuration file for secret API keys")
+	ignoreFile.store_line("appconfig.json")
+	print("Successfully hid 'appconfig.json' file! You should really add that to your .gitignore yourself :/")


### PR DESCRIPTION
Basic security implemented. Keys are stored in a single type, which should be consumed by the API handlers. For example, Discord Rich Presence, which I hope to implement given it's easy and works well

In order to implement this feature, some more packages were needed. Refer to the changes in SquigglesCommon4X.csproj for details

Closes #60 